### PR TITLE
fix: menubar quit button now exits immediately

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,6 @@ async fn main() -> Result<()> {
 
     let receiver = GlobalHotKeyEvent::receiver();
     let mut config = config; // Make config mutable for updates
-    let mut should_quit = false;
 
     // Helper to save config, log, and update menu after config changes
     fn save_and_update(
@@ -161,9 +160,6 @@ async fn main() -> Result<()> {
     }
 
     loop {
-        if should_quit {
-            break;
-        }
         // macOS: Pump the event loop to process global hotkey events
         #[cfg(target_os = "macos")]
         unsafe {
@@ -318,7 +314,7 @@ async fn main() -> Result<()> {
                 tray::TrayCommand::Quit => {
                     tracing::info!("quit requested from menubar");
                     println!("\nShutting down from menubar...");
-                    should_quit = true;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
## Motivation

Quit button in menubar didn't exit app immediately - had delay before checking quit flag.

## Implementation information

Changed Quit handler to break directly instead of setting should_quit flag and waiting for next loop iteration. Removed unused should_quit variable and start-of-loop check.

**Before:** Quit set flag → tokio::select! waits 10ms → next iteration checks flag → breaks  
**After:** Quit breaks immediately

## Supporting documentation

N/A