### PR TITLE
fix: replace custom quit MenuItem with PredefinedMenuItem for CMD+Q support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -325,9 +325,8 @@ async fn main() -> Result<()> {
                             tracing::info!("config file location: {:?}", path);
                         }
                     }
-                }
-                // Note: Quit case removed - PredefinedMenuItem::quit() calls native
-                // macOS terminate: selector which bypasses event system entirely
+                } // Note: Quit case removed - PredefinedMenuItem::quit() calls native
+                  // macOS terminate: selector which bypasses event system entirely
             }
         }
 

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -391,7 +391,6 @@ impl TrayManager {
             "Open Config File" => Some(TrayCommand::OpenConfigFile),
             // Note: "Quit" not handled here - PredefinedMenuItem::quit() uses native
             // macOS terminate: selector which bypasses event system entirely
-
             _ => None,
         }
     }


### PR DESCRIPTION
## Motivation

Quit button in menubar and CMD+Q keyboard shortcut were not working. Apps using `NSApplicationActivationPolicyAccessory` (tray-only apps) require native macOS quit handling via `terminate:` selector.

## Implementation information

- Replaced custom `MenuItem::new("Quit", ...)` with `PredefinedMenuItem::quit(None)`
- `PredefinedMenuItem::quit()` uses native macOS `terminate:` selector which automatically handles both menubar click and CMD+Q
- Removed unused `keyboard_types` dependency and `Accelerator` imports
- Added debug logging for tray menu events

The native `terminate:` selector bypasses custom event handling and directly terminates the app via NSApplication, which is the proper way to handle quit in accessory apps.

## Supporting documentation

Research findings:
- [muda macOS implementation](https://github.com/tauri-apps/muda/blob/dev/src/platform_impl/macos/mod.rs) - shows `PredefinedMenuItemType::Quit` maps to `terminate:` selector
- [winit CMD+Q issue](https://github.com/rust-windowing/winit/issues/41) - discusses CMD+Q handling challenges