### PR TITLE
fix: menu config updates not reflecting immediately in UI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,7 @@ async fn main() -> Result<()> {
     // Helper to save config, log, and update menu after config changes
     fn save_and_update(
         config: &config::Config,
-        tray_manager: &tray::TrayManager,
+        tray_manager: &mut tray::TrayManager,
         success_msg: &str,
         requires_restart: bool,
     ) -> Result<()> {
@@ -283,7 +283,8 @@ async fn main() -> Result<()> {
                 tray::TrayCommand::UpdateHotkey { modifiers, key } => {
                     config.hotkey.modifiers = modifiers;
                     config.hotkey.key = key;
-                    if let Err(e) = save_and_update(&config, &tray_manager, "Hotkey updated", true)
+                    if let Err(e) =
+                        save_and_update(&config, &mut tray_manager, "Hotkey updated", true)
                     {
                         tracing::error!("failed to update config: {:?}", e);
                         println!("⚠ Failed to save config: {}", e);
@@ -291,7 +292,9 @@ async fn main() -> Result<()> {
                 }
                 tray::TrayCommand::UpdateModel { model_type } => {
                     config.model.model_type = model_type;
-                    if let Err(e) = save_and_update(&config, &tray_manager, "Model updated", true) {
+                    if let Err(e) =
+                        save_and_update(&config, &mut tray_manager, "Model updated", true)
+                    {
                         tracing::error!("failed to update config: {:?}", e);
                         println!("⚠ Failed to save config: {}", e);
                     }
@@ -300,7 +303,7 @@ async fn main() -> Result<()> {
                     config.model.threads = threads;
                     if let Err(e) = save_and_update(
                         &config,
-                        &tray_manager,
+                        &mut tray_manager,
                         &format!("Threads updated to {}", threads),
                         false,
                     ) {
@@ -312,7 +315,7 @@ async fn main() -> Result<()> {
                     config.model.beam_size = beam;
                     if let Err(e) = save_and_update(
                         &config,
-                        &tray_manager,
+                        &mut tray_manager,
                         &format!("Beam size updated to {}", beam),
                         false,
                     ) {
@@ -326,7 +329,7 @@ async fn main() -> Result<()> {
                         |l| format!("Language updated to {l}"),
                     );
                     config.model.language = lang;
-                    if let Err(e) = save_and_update(&config, &tray_manager, &msg, false) {
+                    if let Err(e) = save_and_update(&config, &mut tray_manager, &msg, false) {
                         tracing::error!("failed to update config: {:?}", e);
                         println!("⚠ Failed to save config: {}", e);
                     }
@@ -335,7 +338,7 @@ async fn main() -> Result<()> {
                     config.audio.buffer_size = size;
                     if let Err(e) = save_and_update(
                         &config,
-                        &tray_manager,
+                        &mut tray_manager,
                         &format!("Buffer size updated to {}", size),
                         true,
                     ) {
@@ -353,7 +356,7 @@ async fn main() -> Result<()> {
                             "disabled"
                         }
                     );
-                    if let Err(e) = save_and_update(&config, &tray_manager, &msg, true) {
+                    if let Err(e) = save_and_update(&config, &mut tray_manager, &msg, true) {
                         tracing::error!("failed to update config: {:?}", e);
                         println!("⚠ Failed to save config: {}", e);
                     }
@@ -368,7 +371,7 @@ async fn main() -> Result<()> {
                             "disabled"
                         }
                     );
-                    if let Err(e) = save_and_update(&config, &tray_manager, &msg, true) {
+                    if let Err(e) = save_and_update(&config, &mut tray_manager, &msg, true) {
                         tracing::error!("failed to update config: {:?}", e);
                         println!("⚠ Failed to save config: {}", e);
                     }


### PR DESCRIPTION
## Motivation

Users reported that changing configuration from the menu bar doesn't update the visual checkmarks immediately. The config saves to file correctly, but the menu UI doesn't reflect the changes until app restart.

## Implementation information

The root cause is that `tray.set_menu()` doesn't reliably update the macOS NSStatusBar menu. This is similar to the previous `set_icon()` bug that was fixed in commit 2edacb4 by rebuilding the entire tray.

### Changes made:

1. **`TrayManager::update_menu()` method** - Changed to rebuild the entire tray instead of using `set_menu()`
   - This follows the same pattern used in `update_icon_if_needed()` which already works correctly

2. **Menu item ID assignment** - Updated all menu items to use proper text IDs instead of auto-generated numeric ones:
   - Changed `MenuItem::new()` to `MenuItem::with_id()` 
   - Changed `CheckMenuItem::new()` to `CheckMenuItem::with_id()`
   - This ensures `parse_menu_event()` can correctly identify which item was clicked

3. **Mutable reference handling** - Updated function signatures to pass mutable TrayManager reference where needed

### Testing performed:

- Verified all menu config changes update checkmarks immediately without restart
- Tested threads, beam size, language, model, buffer size, preload toggle, and telemetry toggle
- Confirmed config file saves correctly
- Checked debug logs show proper menu event IDs (text labels instead of numeric)

## Supporting documentation

- Issue report: User stated "when I try to change some config from menu bar it does not work, nothing changes in menu bar and in config"
- Similar fix pattern: Commit 2edacb4 fixed icon updates using tray rebuild approach