### PR TITLE
feat: add mise dev task for running app in release mode

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -20,6 +20,10 @@ run = "cargo build"
 description = "Build release binary"
 run = "cargo build --release"
 
+[tasks.dev]
+description = "Run app in release mode"
+run = "mise exec -- cargo run --release"
+
 [tasks.test]
 description = "Run tests"
 run = "cargo test"


### PR DESCRIPTION
## Motivation

Add convenient development task for running the application in release mode using mise-managed toolchain.

## Implementation information

Added `[tasks.dev]` to `.mise.toml` that executes `mise exec -- cargo run --release`. This ensures the app runs with the correct Rust version (1.91) defined in mise config.

Usage: `mise run dev`

## Supporting documentation

N/A